### PR TITLE
MFH: r486150

### DIFF
--- a/emulators/citra/Makefile
+++ b/emulators/citra/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	citra
-PORTVERSION=	s20181126
+PORTVERSION=	s20181128
 PORTREVISION?=	0
 CATEGORIES=	emulators
 
@@ -23,7 +23,7 @@ BUILD_DEPENDS=	boost-libs>=1.66:devel/boost-libs
 
 USE_GITHUB=	yes
 GH_ACCOUNT=	citra-emu
-GH_TAGNAME=	2678c1a94
+GH_TAGNAME=	7e90abec7
 GH_TUPLE=	citra-emu:ext-libressl-portable:7d01cb0:libressl/externals/libressl \
 		citra-emu:ext-soundtouch:060181e:soundtouch/externals/soundtouch \
 		MerryMage:dynarmic:r1-992-g4e6848d1:dynarmic/externals/dynarmic \

--- a/emulators/citra/distinfo
+++ b/emulators/citra/distinfo
@@ -1,6 +1,6 @@
-TIMESTAMP = 1543261387
-SHA256 (citra-emu-citra-s20181126-2678c1a94_GH0.tar.gz) = 383bdc6112cbb8272de52f71c1a638c549b5815e2cd77eae4d6cd8cb45ed9d0f
-SIZE (citra-emu-citra-s20181126-2678c1a94_GH0.tar.gz) = 4659799
+TIMESTAMP = 1543422281
+SHA256 (citra-emu-citra-s20181128-7e90abec7_GH0.tar.gz) = 337844b324dc94afefb356158e7aebad50823052b00b435aa349c902ae35ff25
+SIZE (citra-emu-citra-s20181128-7e90abec7_GH0.tar.gz) = 4659770
 SHA256 (citra-emu-ext-libressl-portable-7d01cb0_GH0.tar.gz) = f3fc8c9d4991b05ca1e1c8f5907ecd3ffd9724a8dccf328087b4784cda5c7db3
 SIZE (citra-emu-ext-libressl-portable-7d01cb0_GH0.tar.gz) = 1762942
 SHA256 (citra-emu-ext-soundtouch-060181e_GH0.tar.gz) = a593ab188e4feaeef8376c27b554cc413986efc777c195e44c6d3d223de9a63c


### PR DESCRIPTION
emulators/citra: update to s20181128

Changes:	https://github.com/citra-emu/citra/compare/2678c1a94...7e90abec7
Approved by:	ports-secteam (swills, implicit for snapshots)